### PR TITLE
Fix NullReferenceException in COSE Key constructor that takes BouncyCastle AsymmetricKeyParameter objects

### DIFF
--- a/COSE/Key.cs
+++ b/COSE/Key.cs
@@ -43,7 +43,7 @@ namespace Com.AugustCellars.COSE
             _map = objKey;
         }
 
-        public OneKey(AsymmetricKeyParameter publicKey, AsymmetricKeyParameter privateKey)
+        public OneKey(AsymmetricKeyParameter publicKey, AsymmetricKeyParameter privateKey) : this()
         {
             if (publicKey != null) {
                 FromKey(publicKey);


### PR DESCRIPTION
This particular constructor doesn't initialize _map, and so FromKey's attempts to call Add on it result in a NullReferenceException. Fix by calling the parameterless constructor first, which does this initialization.